### PR TITLE
[chore] #27 ProductDetailView 이미지 인셋 적용

### DIFF
--- a/PANELNOW/PANELNOW/Presentation/ProductDetail/Cell/ItemImageCell.swift
+++ b/PANELNOW/PANELNOW/Presentation/ProductDetail/Cell/ItemImageCell.swift
@@ -27,7 +27,7 @@ class ItemImageCell: BaseUITableViewCell {
     
     override func setLayout() {
         itemImage.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(36)
+            $0.edges.equalToSuperview().inset(32)
         }
     }
     


### PR DESCRIPTION
## 📟 연결된 이슈
closed #27 

## 🍎 작업 내용
ProductDetailView 이미지 인셋 적용했습니다.

## 📸 스크린샷
| 기능/화면 | Before | After |
|:---------:|:-------------:|:-------------:|
| 스크린샷 | <img src="https://github.com/user-attachments/assets/3794007c-510c-4a06-9ced-b32f146457ce" width="250"> | <img src="https://github.com/user-attachments/assets/2defe97a-ef77-4cb0-8e67-9ef2a1b451a7" width="250"> |

## 💬 리뷰 코멘트
인셋 추가했습니다.
